### PR TITLE
Fix typo in save_images.rb

### DIFF
--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -143,7 +143,7 @@ class Wraith::SaveImages
           crop_selector(driver, selector, new_file_name) if selector && selector.length > 0
           break
         rescue Net::ReadTimeout => e
-          logger.error "Got #{e} on attempt #{attempt} at screen size #{screensize}. URL = #{url}"
+          logger.error "Got #{e} on attempt #{attempt} at screen size #{screen_size}. URL = #{url}"
         end
       end
     end


### PR DESCRIPTION
`#{screensize}` -> `#{screen_size}`